### PR TITLE
Install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ A CLI that creates reproducible Kubernetes environments for development and test
 ## Linux
 
 ```
-GETDECK=$(curl -L -s https://api.github.com/repos/Schille/deck/releases/latest | grep '"browser_download_url": ".*linux.*"' | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*") && curl -LO $GETDECK && unzip -o $(echo $GETDECK | grep -oE '[^/]+$') deck && sudo install -o root -g root -m 0755 deck /usr/local/bin/deck
+curl -sSL https://raw.githubusercontent.com/getdeck/getdeck/main/install.sh | sh - 
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-download_url=$(curl -L -s https://api.github.com/repos/Schille/deck/releases/latest | grep '"browser_download_url": ".*linux.*"' | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*")
+download_url=$(curl -L -s https://api.github.com/repos/getdeck/getdeck/releases/latest | grep '"browser_download_url": ".*linux.*"' | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*")
 file_name=$(echo $download_url | grep -oE '[^/]+$')
 curl -L $download_url -o /tmp/$file_name
 unzip -o /tmp/$file_name -d /tmp/deck

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+download_url=$(curl -L -s https://api.github.com/repos/Schille/deck/releases/latest | grep '"browser_download_url": ".*linux.*"' | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*")
+file_name=$(echo $download_url | grep -oE '[^/]+$')
+curl -L $download_url -o /tmp/$file_name
+unzip -o /tmp/$file_name -d /tmp/deck
+sudo install -o root -g root -m 0755 /tmp/deck/deck /usr/local/bin/deck
+
+# cleanup 
+rm -rf /tmp/$file_name
+rm -rf /tmp/deck


### PR DESCRIPTION
This simplifies the installation for the user by downloading and executing a installation script. I also added cleanup to this script.

Some ideas: 

- We might want to allow to pass a specific version to the installer.
- We might want to make the location of installation configurable (I'd want to have the binaries in `~/.local/bin`)
- I am not sure how the multi platform plans are and if this is maybe a step in the wrong direction.