### PR TITLE
feat(installer): Check installation dependencies before execution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,24 @@ case $OS in
 		;;
 esac
 
+# Check for install dependency availability
+if ! [ -x "$(command -v curl)" ]; then
+       echo "❌ curl is required to execute the installation. Please install it and run the installer again!"
+       exit
+fi
+if ! [ -x "$(command -v unzip)" ]; then
+       echo "❌ Unzip is required to execute the installation. Please install it and run the installer again!"
+       exit
+fi
+if ! [ -x "$(command -v sudo)" ]; then
+       echo "❌ sudo is required to execute the installation. Please install it and run the installer again!"
+       exit
+fi
+if ! [ -x "$(command -v install)" ]; then
+       echo "❌ install is required to execute the installation. Please install it and run the installer again!"
+       exit
+fi
+
 download_url=$(curl -L -s https://api.github.com/repos/getdeck/getdeck/releases/latest | grep '"browser_download_url": ".*'$OS'.*"' | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*")
 file_name=$(echo $download_url | grep -oE '[^/]+$')
 curl -L $download_url -o /tmp/$file_name


### PR DESCRIPTION
One thing we might want to do is checking for a git executable as well, since `deck version` will fail if its not available:

```
Traceback (most recent call last):
  File "git", line 87, in <module>
  File "git", line 76, in refresh
  File "git.cmd", line 341, in refresh
ImportError: Bad git executable.
The git executable must be specified in one of the following ways:
    - be included in your $PATH
    - be set via $GIT_PYTHON_GIT_EXECUTABLE
    - explicitly set via git.refresh()

All git commands will error until this is rectified.

This initial warning can be silenced or aggravated in the future by setting the
$GIT_PYTHON_REFRESH environment variable. Use one of the following values:
    - quiet|q|silence|s|none|n|0: for no warning or exception
    - warn|w|warning|1: for a printed warning
    - error|e|raise|r|2: for a raised exception

Example:
    export GIT_PYTHON_REFRESH=quiet


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "getdeck.__main__", line 114, in main
  File "getdeck.api", line 2, in <module>
  File "getdeck.api.get", line 7, in <module>
  File "getdeck.api.hosts", line 10, in <module>
  File "getdeck.utils", line 10, in <module>
  File "getdeck.deckfile.fetch.deck_fetcher", line 11, in <module>
  File "git", line 89, in <module>
ImportError: Failed to initialize: Bad git executable.
The git executable must be specified in one of the following ways:
    - be included in your $PATH
    - be set via $GIT_PYTHON_GIT_EXECUTABLE
    - explicitly set via git.refresh()

All git commands will error until this is rectified.

This initial warning can be silenced or aggravated in the future by setting the
$GIT_PYTHON_REFRESH environment variable. Use one of the following values:
    - quiet|q|silence|s|none|n|0: for no warning or exception
    - warn|w|warning|1: for a printed warning
    - error|e|raise|r|2: for a raised exception

Example:
    export GIT_PYTHON_REFRESH=quiet
```